### PR TITLE
fix in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A CLI interface for [juice](https://github.com/andrewrk/juice).
 # Install
 
 ```
-npm install spreaker-css-inliner
+npm install -g spreaker-css-inliner
 ```
 
 


### PR DESCRIPTION
In order to have access to the binary in your path, you need to install it as a global npm module
